### PR TITLE
Refactor API endpoints (and related changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.6.0",
-    "netlify-cli": "^2.11.16",
+    "netlify-cli": "^2.11.17",
     "netlify-lambda": "^1.4.7",
     "node-sass": "^4.12.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/src/functions/location-and-weather.js
+++ b/src/functions/location-and-weather.js
@@ -1,0 +1,129 @@
+const bugsnag = require('@bugsnag/js');
+const AWS = require('aws-sdk');
+const FunctionShield = require('@puresec/function-shield');
+const rp = require('request-promise');
+
+const bugsnagClient = bugsnag(process.env.BUGSNAG_KEY);
+FunctionShield.configure({
+  policy: {
+    outbound_connectivity: 'alert',
+    read_write_tmp: 'block',
+    create_child_process: 'block',
+    read_handler: 'block',
+  },
+  token: process.env.FUNCTION_SHIELD_TOKEN,
+});
+
+exports.handler = async (event, context, callback) => {
+  const { lat, lng } = event.queryStringParameters;
+  const callbackHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+
+  if (!lat) {
+    callback(null, {
+      statusCode: 400,
+      headers: callbackHeaders,
+      body: 'Missing "lat" parameter',
+    });
+  }
+  if (!lng) {
+    callback(null, {
+      statusCode: 400,
+      headers: callbackHeaders,
+      body: 'Missing "lng" parameter',
+    });
+  }
+
+  const units = event.queryStringParameters.units || 'auto';
+  const geocodeApiUrl = `https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${process.env.GOOGLE_MAPS_API_KEY}`;
+  const weatherApiUrl = `https://api.darksky.net/forecast/${process.env.DARK_SKY_KEY}/${lat},${lng}/?units=${units}`;
+
+  const geocodeOptions = {
+    uri: geocodeApiUrl,
+    headers: {
+      'User-Agent': 'Request-Promise',
+    },
+    json: true,
+  };
+  const geocodePromise = rp(geocodeOptions)
+    .then((response) => {
+      const fullResults = response.results;
+      const formattedAddress = response.results[0].formatted_address;
+      let locationName = '';
+      const addressTargets = ['neighborhood', 'locality', 'administrative_area_level_1'];
+      addressTargets.map((target) => {
+        if (!locationName.length) {
+          response.results.map((result) => {
+            if (!locationName.length) {
+              result.address_components.map((component) => {
+                if (!locationName.length && component.types.indexOf(target) > -1) {
+                  locationName = component.long_name;
+                }
+              });
+            }
+          });
+        }
+      });
+      if (locationName.length) {
+        // console.log(locationName);
+        const locationData = {
+          location: {
+            locationName,
+            formattedAddress,
+            fullResults,
+          },
+        };
+        return locationData;
+      }
+    })
+    .catch((error) => {
+      // console.error(error);
+      callback(bugsnagClient.notify(error), {
+        statusCode: 500,
+        headers: callbackHeaders,
+        body: JSON.stringify(error),
+      });
+    });
+
+  const weatherOptions = {
+    uri: weatherApiUrl,
+    headers: {
+      'User-Agent': 'Request-Promise',
+    },
+    json: true,
+  };
+  const weatherPromise = rp(weatherOptions)
+    .then((response) => {
+      const weatherData = {
+        weather: response,
+      };
+      return weatherData;
+    })
+    .catch((error) => {
+      // console.error(error);
+      callback(bugsnagClient.notify(error), {
+        statusCode: 500,
+        headers: callbackHeaders,
+        body: JSON.stringify(error),
+      });
+    });
+
+  Promise.all(
+    [geocodePromise, weatherPromise],
+  ).then((response) => {
+    callback(null, {
+      statusCode: 200,
+      headers: callbackHeaders,
+      body: JSON.stringify(response),
+    });
+  }).catch((error) => {
+    // console.error(error);
+    callback(bugsnagClient.notify(error), {
+      statusCode: 500,
+      headers: callbackHeaders,
+      body: JSON.stringify(error),
+    });
+  });
+};

--- a/src/js/modules/cache.js
+++ b/src/js/modules/cache.js
@@ -23,7 +23,6 @@ export function areCachesEmpty() {
     (getData(defaults.cacheTimeKey) === null)
     || (getData(defaults.weatherDataKey) === null)
     || (getData(defaults.locationDataKey) === null)
-    || (getData(defaults.locationNameDataKey) === null)
   );
 }
 

--- a/src/js/modules/cache.js
+++ b/src/js/modules/cache.js
@@ -42,13 +42,7 @@ export function setCacheTime() {
 }
 
 export function initCache() {
-  if (areCachesEmpty()) {
-    resetData();
-    setCacheTime();
-  } else {
-    defaults.loadFromCache = useCache(getData(defaults.cacheTimeKey));
-  }
-  if (!defaults.loadFromCache) {
+  if (areCachesEmpty() || !useCache(getData(defaults.cacheTimeKey))) {
     resetData();
     setCacheTime();
   }

--- a/src/js/modules/data.js
+++ b/src/js/modules/data.js
@@ -6,49 +6,6 @@ export function loadFromCache() {
   return useCache(getData(defaults.cacheTimeKey));
 }
 
-export function parseLocationNameFromFormattedAddress(address) {
-  try {
-    const cityPosition = address.split(',').length > 2 ? address.split(',').length - 3 : 0;
-    return address.split(',')[cityPosition].trim();
-  } catch (error) {
-    /* eslint-disable no-undef */
-    return bugsnagClient.notify(error); // defined in html page
-    /* eslint-enable no-undef */
-  }
-}
-
-export async function getLocationNameFromLatLng(lat, lng) {
-  const url = `${defaults.apiUrl()}/location-name/?lat=${lat}&lng=${lng}`;
-  if (loadFromCache()) {
-    const cachedLocationName = getData(defaults.locationNameDataKey);
-    try {
-      defaults.locationName = cachedLocationName;
-      return parseLocationNameFromFormattedAddress(cachedLocationName);
-    } catch (error) {
-      /* eslint-disable no-undef */
-      bugsnagClient.notify(error); // defined in html page
-      /* eslint-enable no-undef */
-      return defaults.locationName;
-    }
-  } else {
-    const locationData = await axios.get(url)
-      .then((response) => {
-        setData(defaults.locationDataKey, response.data);
-        const fullLocationName = response.data.results[0].formatted_address;
-        const shortLocationName = parseLocationNameFromFormattedAddress(fullLocationName);
-        setData(defaults.locationNameDataKey, fullLocationName);
-        defaults.locationName = fullLocationName;
-        return shortLocationName;
-      })
-      .catch((error) => {
-        /* eslint-disable no-undef */
-        bugsnagClient.notify(error); // defined in html page
-        /* eslint-enable no-undef */
-      });
-    return locationData;
-  }
-}
-
 export async function getWeatherData(lat, lng) {
   const url = `${defaults.apiUrl()}/weather/?lat=${lat}&lng=${lng}`;
   if (loadFromCache()) {
@@ -65,29 +22,4 @@ export async function getWeatherData(lat, lng) {
       defaults.handleError(error);
     });
   return weatherData;
-}
-
-export async function getLocationAndPopulateAppData(lat, lng) {
-  let weatherDataToReturn;
-  if (loadFromCache()) {
-    try {
-      const cachedLocationData = getData(defaults.locationDataKey);
-      defaults.locationName = cachedLocationData.formatted_address;
-      weatherDataToReturn = getData(defaults.weatherDataKey);
-    } catch (error) {
-      /* eslint-disable no-undef */
-      bugsnagClient.notify(error); // defined in html page
-      /* eslint-enable no-undef */
-    }
-  } else {
-    try {
-      await getLocationNameFromLatLng(lat, lng);
-      weatherDataToReturn = await getWeatherData(lat, lng);
-    } catch (error) {
-      /* eslint-disable no-undef */
-      bugsnagClient.notify(error); // defined in html page
-      /* eslint-enable no-undef */
-    }
-  }
-  return weatherDataToReturn;
 }

--- a/src/js/modules/data.js
+++ b/src/js/modules/data.js
@@ -61,9 +61,8 @@ export async function getWeatherData(lat, lng) {
       return response.data;
     })
     .catch((error) => {
-      /* eslint-disable no-undef */
-      bugsnagClient.notify(error); // defined in html page
-      /* eslint-enable no-undef */
+      // add error notification to user with option to reload/retry
+      defaults.handleError(error);
     });
   return weatherData;
 }

--- a/src/js/modules/defaults.js
+++ b/src/js/modules/defaults.js
@@ -17,6 +17,7 @@ module.exports = {
   loadingSpinnerSelector: '.loading-message',
   loadingText: '... loading weather data for your location ...',
   locationDataKey: 'locationData',
+  locationAddressDataKey: 'locationAddress',
   locationNameDataKey: 'locationName',
   locationName: '',
   offlineHeading: 'You appear to be offline',
@@ -26,10 +27,13 @@ module.exports = {
   title: 'LocalWeather.io (powered by Dark Sky)',
   versionString: `v${versionNumber}`,
   weatherDataKey: 'weatherData',
-  apiUrl() {
-    return window.location.hostname === 'localhost' ? 'http://localhost:9000' : `https://${window.location.hostname}/.netlify/functions`;
+  apiUrl: () => {
+    if (window.location.hostname === 'localhost') {
+      return 'http://localhost:9000';
+    }
+    return `https://${window.location.hostname}/.netlify/functions`;
   },
-  canonical() {
+  canonical: () => `https://${window.location.hostname}/`,
   handleError: (error) => {
     if (window.location.hostname === 'localhost') {
       console.error(error);

--- a/src/js/modules/defaults.js
+++ b/src/js/modules/defaults.js
@@ -30,7 +30,14 @@ module.exports = {
     return window.location.hostname === 'localhost' ? 'http://localhost:9000' : `https://${window.location.hostname}/.netlify/functions`;
   },
   canonical() {
-    return `https://${window.location.hostname}/`;
+  handleError: (error) => {
+    if (window.location.hostname === 'localhost') {
+      console.error(error);
+    } else {
+      /* eslint-disable no-undef */
+      bugsnagClient.notify(error);
+      /* eslint-enable no-undef */
+    }
   },
   isOnline() {
     return navigator.onLine;

--- a/src/js/modules/init.js
+++ b/src/js/modules/init.js
@@ -67,11 +67,8 @@ registerServiceWorker();
 
 export function init() {
   window.onerror = (msg, url, lineNo, columnNo, error) => {
-    console.error('ERROR', msg, url, lineNo, columnNo, error);
     hideLoading();
-    /* eslint-disable no-undef */
-    bugsnagClient.notify(error);
-    /* eslint-enable no-undef */
+    defaults.handleError(error);
     return false;
   };
 

--- a/src/js/modules/templates.js
+++ b/src/js/modules/templates.js
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import * as defaults from './defaults';
-import { parseLocationNameFromFormattedAddress } from './data';
 import { getData } from './cache';
 
 const getWeatherIcon = icon => defaults.iconMap[icon];
@@ -67,15 +66,16 @@ const addLocationNameSpacing = () => {
 
 export function populateLocation(data) {
   const locationName = getData(defaults.locationNameDataKey);
+  const locationAddress = getData(defaults.locationAddressDataKey);
   const locationTemplate = `
     <div class="column">
       <h1 class="title is-1 has-text-centered has-tooltip location-name" data-tippy-content="
         <i class='fas fa-fw fa-globe'></i>
-        <strong>${locationName}</strong>
+        <strong>${locationAddress}</strong>
         <br>
         <i class='fas fa-fw fa-map-marker-alt'></i>
         ${Math.fround(data.latitude).toFixed(4)},${data.longitude.toFixed(4)}
-      ">${parseLocationNameFromFormattedAddress(locationName)}</h1>
+      ">${locationName}</h1>
     </div>
   `;
   const locationEl = document.querySelector('.location');

--- a/src/js/modules/ui.js
+++ b/src/js/modules/ui.js
@@ -19,9 +19,7 @@ import {
 } from '@fortawesome/pro-light-svg-icons';
 import dayjs from 'dayjs';
 import * as defaults from './defaults';
-import {
-  getLocationAndPopulateAppData,
-} from './data';
+import { getWeatherData } from './data';
 import { getData } from './cache';
 import {
   populateMessage, populateForecastData,
@@ -404,7 +402,7 @@ export function renderAppWithData(data) {
 export async function getWeatherDataAndRenderApp(lat, lng) {
   showLoading('... loading weather data ...');
   try {
-    const weatherData = await getLocationAndPopulateAppData(lat, lng);
+    const weatherData = await getWeatherData(lat, lng);
     renderAppWithData(weatherData);
     hideLoading();
   } catch (error) {

--- a/src/js/modules/ui.js
+++ b/src/js/modules/ui.js
@@ -20,7 +20,6 @@ import {
 import dayjs from 'dayjs';
 import * as defaults from './defaults';
 import {
-  parseLocationNameFromFormattedAddress,
   getLocationAndPopulateAppData,
 } from './data';
 import { getData } from './cache';
@@ -185,8 +184,7 @@ export function setFavicon(data) {
 }
 
 export function setTitle(data) {
-  const locationName = getData(defaults.locationNameDataKey);
-  const newTitle = `${Math.round(data.currently.temperature)}° ${data.currently.summary} | ${parseLocationNameFromFormattedAddress(locationName)} | ${defaults.title}`;
+  const newTitle = `${Math.round(data.currently.temperature)}° ${data.currently.summary} | ${getData(defaults.locationNameDataKey)} | ${defaults.title}`;
   window.document.title = newTitle;
 }
 

--- a/src/js/modules/ui.js
+++ b/src/js/modules/ui.js
@@ -408,14 +408,12 @@ export async function getWeatherDataAndRenderApp(lat, lng) {
   try {
     const weatherData = await getLocationAndPopulateAppData(lat, lng);
     renderAppWithData(weatherData);
+    hideLoading();
   } catch (error) {
-    /* eslint-disable no-undef */
-    bugsnagClient.notify(error); // defined in html page
-    /* eslint-enable no-undef */
-    // console.log(error);
+    defaults.handleError(error);
+    // show error message to user
     hideLoading();
   }
-  hideLoading();
 }
 
 export async function geoSuccess(position) {
@@ -484,10 +482,7 @@ export function initGeolocation() {
         showLoading('... acquiring location ...');
         navigator.geolocation.getCurrentPosition(geoSuccess, geoError, defaults.geolocationOptions);
       } catch (error) {
-        /* eslint-disable no-undef */
-        bugsnagClient.notify(error); // defined in html page
-        /* eslint-enable no-undef */
-        // console.log(error);
+        defaults.handleError(error);
         // TODO: Show friendly message to user
       }
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,34 +1533,34 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@octokit/endpoint@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-4.0.0.tgz#97032a6690ef1cf9576ab1b1582c0ac837e3b5b6"
-  integrity sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==
+"@octokit/endpoint@^5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.1.1.tgz#bd96a67d141bd897fd5357501fcea44791870925"
+  integrity sha512-kCv3ZyqFTWGYmvuU0TETzC4jPGzyLCJrjXp65kRe9DHyQULZak+dpwmEbT7M2rpdr/O2im8ivrPGT6J+2WsKNg==
   dependencies:
     deepmerge "3.2.0"
-    is-plain-object "^2.0.4"
+    is-plain-object "^3.0.0"
     universal-user-agent "^2.0.1"
     url-template "^2.0.8"
 
-"@octokit/request@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-3.0.1.tgz#21e888c6dce80566ec69477360bab79f2f14861f"
-  integrity sha512-aH61OVkMKMofGW/go2x4mJ44X4U/JF8xsiFFictwkZYtz0psE8OPKpsP2TZBZaJoCg2wmeTyEgqGfY+veg0hGQ==
+"@octokit/request@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-3.0.2.tgz#dd2424691f486d7ea332ec06e3de55b1ea13c5dc"
+  integrity sha512-lBH2hf2Yuh9XlmP3MSpn3jL9DyCGG+cuPXDRQiJMK42BwW6xFhwWmG1k6xWykcLM4GwZG/5fuwcqnQXYG0ZTSg==
   dependencies:
-    "@octokit/endpoint" "^4.0.0"
+    "@octokit/endpoint" "^5.1.0"
     deprecation "^1.0.1"
     is-plain-object "^3.0.0"
     node-fetch "^2.3.0"
     once "^1.4.0"
     universal-user-agent "^2.0.1"
 
-"@octokit/rest@^16.25.2":
-  version "16.25.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.2.tgz#51fede6d35af5ecc92f1e7feacad89abbcd2b0e8"
-  integrity sha512-aUSzvY33dz6RMLLmT+1aNc2OvvAmDfdXKaOzFEEBNJjsjckNjWkB2hgGa5plnnbuLPCloVldPuAdm+8REZGLcg==
+"@octokit/rest@^16.25.3":
+  version "16.25.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.3.tgz#ce9e7a6230d20d58574ec929f622f2778ead7eb4"
+  integrity sha512-/6/Isn9pNoKUQwuWUaskxMC6kFxtXTHhzsgYbyirEQ3UvcLciHvPgtRTbuV3bbVf0x4+4WEfKaI9UzxmPQ3W3A==
   dependencies:
-    "@octokit/request" "3.0.1"
+    "@octokit/request" "3.0.2"
     atob-lite "^2.0.0"
     before-after-hook "^1.4.0"
     btoa-lite "^1.0.0"
@@ -8556,10 +8556,10 @@ netlify-cli-logo@^1.0.0:
   dependencies:
     chalk "^2.4.2"
 
-netlify-cli@^2.11.16:
-  version "2.11.16"
-  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-2.11.16.tgz#663011874799fd27ab924f96768c88c7252c68b9"
-  integrity sha512-ZbvW0epwcEoKUwNvu9i6hkb0gTeqZb8hUzdxfOakIBFrBSIwTfykIQqHQqJMQEozYYN0/ImRYhpDhx0X0WpHiQ==
+netlify-cli@^2.11.17:
+  version "2.11.17"
+  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-2.11.17.tgz#d950b7dddfa69e86c895d527d660c0c69699742c"
+  integrity sha512-klASzpidDNm3zNsUylrl06rXL9ff+andom19lu+U/qcmtaH3jrAiEEgx6/rxgcqefThT9mQD7e5Ea55BYIEdMw==
   dependencies:
     "@netlify/cli-utils" "^1.0.2"
     "@oclif/command" "^1.5.13"
@@ -8568,7 +8568,7 @@ netlify-cli@^2.11.16:
     "@oclif/plugin-help" "^2.1.6"
     "@oclif/plugin-not-found" "^1.1.4"
     "@oclif/plugin-plugins" "^1.7.8"
-    "@octokit/rest" "^16.25.2"
+    "@octokit/rest" "^16.25.3"
     ansi-styles "^3.2.1"
     ascii-table "0.0.9"
     chalk "^2.4.2"
@@ -8587,7 +8587,7 @@ netlify-cli@^2.11.16:
     lodash.isequal "^4.5.0"
     log-symbols "^2.2.0"
     netlify "^2.4.4"
-    netlify-dev-plugin "^1.0.17"
+    netlify-dev-plugin "^1.0.18"
     node-fetch "^2.5.0"
     ora "^3.4.0"
     p-wait-for "^2.0.0"
@@ -8596,10 +8596,10 @@ netlify-cli@^2.11.16:
     random-item "^1.0.0"
     update-notifier "^2.5.0"
 
-netlify-dev-plugin@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/netlify-dev-plugin/-/netlify-dev-plugin-1.0.17.tgz#3c0ab3b5cd94a0bd8fb5b961eb65c9d56da2b412"
-  integrity sha512-dFx2+oLucjZoki8ehmVv7HJ6v4ioejswANhbADGECs/0NAVQjgh/lVDot06P1X2aECvi9+Dalnp1aS3JuRar0w==
+netlify-dev-plugin@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/netlify-dev-plugin/-/netlify-dev-plugin-1.0.18.tgz#78144f26cf17ea0159043bbd5def08b52e4125e4"
+  integrity sha512-mkEGDYKfIea/dH3mHA7CajiagnVJ+xI0Me90Q8oIUQfIryckEStCZwqZGSIIrVLxFX+2Zna2Ku4SA1ld2YgMug==
   dependencies:
     "@netlify/cli-utils" "^1.0.1"
     "@netlify/rules-proxy" "^0.1.3"


### PR DESCRIPTION
- :sparkles: Add new api end-point that returns location and weather data
  - :rocket: Adds logic to determine location name so similar logic can be removed from client-side code:
    - Returns an array with two items, first is location and second is weather
    - Returns location name and address as their own keys in the weather data
- :recycle: Refactor areCachesEmpty function
- :recycle: Refactor initCache function
- :sparkles: Add handleError function vs only using Bugsnag
  - :loud_sound: Uses console.log for errors on localhost
  - :bug: Sends production errors to bugsnag
- :rotating-light: Remove linter warnings and add locationAddressDataKey variable
- :recycle: Refactor to use new handleError function
- :recycle: Refactor to use latest API updates
- :fire: Remove functions that are no longer needed
- :recycle: Refactor for API and function name updates
- :arrow_up: Upgrade `netlify-cli` dependency

_9 changed files with 184 additions and 132 deletions._